### PR TITLE
Fix: Removing Last Resolved Comments

### DIFF
--- a/submit_pullrequest_here/deny_tif.txt
+++ b/submit_pullrequest_here/deny_tif.txt
@@ -85,7 +85,7 @@ mywebshield-ww5.com
 newstaticclientstack.com
 newstaticdatacloud.com
 offensivejokescolin.com
-ogrovom.xyz	2024-02-20
+ogrovom.xyz
 ourclientinputsrv.com
 ourinfoonlinestack.com
 ourstaticdatastorage.com
@@ -96,7 +96,7 @@ qdfs.in
 qqqrhhpeumyk.ru
 qxsf.in
 rohgoruhgsorhugih.ru
-rscz.in	2024-02-18
+rscz.in
 scmpacdn.com
 shopstoregamese.com
 simonettemaddison.net


### PR DESCRIPTION
There were comments with last resolved dates, which can cause Problem while parsing the Domains.