### PR TITLE
modify parameters about actions/checkout

### DIFF
--- a/.github/workflows/purge.yml
+++ b/.github/workflows/purge.yml
@@ -19,7 +19,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 20
+          fetch-tags: 'true'
       - name: Create a Release
         uses: List-KR/semver-release@2.1.3
   jsdelivrpurge:
@@ -36,7 +37,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 20
+          fetch-tags: 'true'
       - name: Run jsDelivr-Purge
         uses: List-KR/jsdelivr-purge@5.6.0
     needs: release


### PR DESCRIPTION
https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
GitHub has reduced storage size of standard GitHub-hosted runners for public repositories.