### PR TITLE
Allow XProtect Updates for Apple Devices

### DIFF
--- a/submit_pullrequest_here/allow_light-ultimate.txt
+++ b/submit_pullrequest_here/allow_light-ultimate.txt
@@ -11,6 +11,9 @@
 
 # BEGIN
 
+# https://github.com/hagezi/dns-blocklists/issues/2481
+# Despite this domain is known to be a tracker, it is necassary to unblock it to keep mandatory security updates (XProtect) for Apple Devices to work!
+
 # https://github.com/hagezi/dns-blocklists/issues/2480
 ymstat.com
 

--- a/submit_pullrequest_here/allow_light-ultimate.txt
+++ b/submit_pullrequest_here/allow_light-ultimate.txt
@@ -13,6 +13,7 @@
 
 # https://github.com/hagezi/dns-blocklists/issues/2481
 # Despite this domain is known to be a tracker, it is necassary to unblock it to keep mandatory security updates (XProtect) for Apple Devices to work!
+xp.apple.com
 
 # https://github.com/hagezi/dns-blocklists/issues/2480
 ymstat.com


### PR DESCRIPTION
Despite this domain is known to be a tracker, it is necassary to unblock it to keep mandatory security updates (XProtect) for Apple Devices to work!