### PR TITLE
Update allow_tif.txt - Allow jjpool.fr domain

### DIFF
--- a/submit_pullrequest_here/allow_tif.txt
+++ b/submit_pullrequest_here/allow_tif.txt
@@ -17,4 +17,6 @@ keen.com
 analytics.arpae.it
 www.arpae.it # CNAME
 
+jjpool.fr
+
 # END


### PR DESCRIPTION
Hello, I'm the owner of jjpool.fr and a user just noticed me that his ADGuard is blocking the site because of this list.
The site is legit and I'm not doing anything malicious, it's an pool mining interface that just calls apis for stats display.