### PR TITLE
Add shipmenttracking.costco.com

### DIFF
--- a/submit_pullrequest_here/allow_light-ultimate.txt
+++ b/submit_pullrequest_here/allow_light-ultimate.txt
@@ -11,6 +11,9 @@
 
 # BEGIN
 
+#https://github.com/hagezi/dns-blocklists/issues/2663
+shipmenttracking.costco.com
+
 # https://github.com/hagezi/dns-blocklists/issues/2651
 openinstall.io
 e.kuaishou.com


### PR DESCRIPTION
Allow Shipment Tracking for Costco ECommerce.
https://github.com/hagezi/dns-blocklists/issues/2663