### PR TITLE
Add IP Identification Endpoint

### DIFF
--- a/submit_pullrequest_here/allow_light-ultimate.txt
+++ b/submit_pullrequest_here/allow_light-ultimate.txt
@@ -11,6 +11,11 @@
 
 # BEGIN
 
+# TG Report:
+ip6.seeip.org
+seeip.org
+# Open Source IPv6 ipv4 address identification endpoint.
+
 # https://github.com/hagezi/dns-blocklists/issues/2774
 clarity.*.moventus.com
 


### PR DESCRIPTION
TG Report:
ip6.seeip.org
seeip.org
Open Source IPv6 ipv4 address identification endpoint.
!!! UNTESTED !!!