### PR TITLE
Allow *-dnsotls-ds.metric.gstatic.com

### DIFF
--- a/controld/analytics-wildcard-allow-folder.json
+++ b/controld/analytics-wildcard-allow-folder.json
@@ -13,6 +13,13 @@
         "do": 1,
         "status": 1
       }
+    },
+    {
+      "PK": "*-dnsotls-ds.metric.gstatic.com",
+      "action": {
+        "do": 1,
+        "status": 1
+      }
     }
   ]
 }


### PR DESCRIPTION
Allow ```*-dnsotls-ds.metric.gstatic.com``` to prevent DoT breakage on Android powered devices