### PR TITLE
Update allow_spam_TLDs.txt

### DIFF
--- a/submit_pullrequest_here/allow_spam_TLDs.txt
+++ b/submit_pullrequest_here/allow_spam_TLDs.txt
@@ -181,6 +181,7 @@ medium.rip
 scribe.rip
 gone.run
 paired.run
+rivet.run
 winget.run
 ecopulse.sbs
 moae.sbs


### PR DESCRIPTION
Legitimate domain, required for online games (Ex. https://diep.io/)