### PR TITLE
Allow adsb.lol

### DIFF
--- a/adblock/spam-tlds.txt
+++ b/adblock/spam-tlds.txt
@@ -103,7 +103,7 @@
 ||*.llp^
 ||*.loan^
 ||*.loans^
-||*.lol^$denyallow=broke.lol|browser.lol|hubcloud.lol|io.lol|kizuki.lol|lemy.lol|library.lol|limetorrents.lol|nos.lol|noted.lol|objection.lol|omg.lol|paste.lol|proven.lol|social.lol|status.lol|weblog.lol
+||*.lol^$denyallow=adsb.lol|broke.lol|browser.lol|hubcloud.lol|io.lol|kizuki.lol|lemy.lol|library.lol|limetorrents.lol|nos.lol|noted.lol|objection.lol|omg.lol|paste.lol|proven.lol|social.lol|status.lol|weblog.lol
 ||*.love^
 ||*.ltd^$denyallow=homebrew.ltd
 ||*.luxe^


### PR DESCRIPTION
legit plane tracking website, quote from the website:
> ADSB.lol is an unfiltered flight tracker with a focus on open data.