### PR TITLE
Update allow_tif-ips.txt

### DIFF
--- a/submit_pullrequest_here/allow_tif-ips.txt
+++ b/submit_pullrequest_here/allow_tif-ips.txt
@@ -9,6 +9,9 @@
 
 # BEGIN
 
+# Namecheap
+198.54.117.242
+
 # fonts.gstatic.com
 172.217.169.67
 172.217.18.3


### PR DESCRIPTION
198.54.117.242 is a legitimate IP address owned by Namecheap, as can be seen here: https://whatismyipaddress.com/ip/198.54.117.242 - Causes breakage when blocked (ex. `raa.namecheap.com`)

(PS it's Retold3202 - Did a much needed username change... hope you've been well)