### PR TITLE
Allow nostr.wine in TLDs

### DIFF
--- a/submit_pullrequest_here/allow_spam_TLDs.txt
+++ b/submit_pullrequest_here/allow_spam_TLDs.txt
@@ -302,6 +302,7 @@ usermanual.wiki
 w.wiki
 zeppelin.wiki
 activated.win
+nostr.wine
 elphago.work
 frame.work
 koding.work


### PR DESCRIPTION
Unblocks nostr.wine - Legitimate domain, Nostr Relay