### PR TITLE
Update allow_spam_TLDs.txt

### DIFF
--- a/submit_pullrequest_here/allow_spam_TLDs.txt
+++ b/submit_pullrequest_here/allow_spam_TLDs.txt
@@ -73,6 +73,8 @@ justget.fit
 pridegym.fit
 union.fit
 helloworld.foo
+e.foundation
+grapheneos.foundation
 apollo.fyi
 better.fyi
 genderdysphoria.fyi


### PR DESCRIPTION
Unblocks `grapheneos.foundation` - Legitimate domain operated by [GrapheneOS](https://grapheneos.org/), & `e.foundation`, legitimate domain operated by the [e Foundation](https://e.foundation/about-e/#foundation)