### PR TITLE
Block bromite.org

### DIFF
--- a/submit_pullrequest_here/deny_tif.txt
+++ b/submit_pullrequest_here/deny_tif.txt
@@ -10,6 +10,9 @@
 
 # BEGIN
 
+# https://infosec.exchange/@divested/113226945978043050
+bromite.org
+
 # Misc
 
 hapdw.gdsdsgskd8.com


### PR DESCRIPTION
Former widely used privacy & security hardened Chromium browser for Android, used for ex. downloads & updates, and also provided a filterlist used by other Android Chromium-based browsers.

Developer went AWOL in December 2022, and the domain is set to expire on October 10th, meaning it'll be snatched up and possibly abused.

More info: https://infosec.exchange/@divested/113226945978043050