### PR TITLE
Update deny_tif.txt

### DIFF
--- a/submit_pullrequest_here/deny_tif.txt
+++ b/submit_pullrequest_here/deny_tif.txt
@@ -1,5 +1,9 @@
 # Domains to be added to the threat intelligence feeds list.
 
+# "Shein Mystery Box Giveaway Winner" Phishing
+formally-up.com
+lvrv0gkspz.blob.core.windows.net
+
 # Netflix phishing
 aktivierung-info.com
 


### PR DESCRIPTION
Spam/phishing email I received...
![image](https://github.com/user-attachments/assets/db38056b-13c3-4ee1-b0ef-3492d3e4d083)

The links go to `lvrv0gkspz.blob.core.windows.net`, which redirects to `formally-up.com`.