### PR TITLE
Block zwbufziw6o4q92.s3.amazonaws.com

### DIFF
--- a/submit_pullrequest_here/deny_tif.txt
+++ b/submit_pullrequest_here/deny_tif.txt
@@ -1,5 +1,9 @@
 # Domains to be added to the threat intelligence feeds list.
 
+# Same crowd as the "Shein Mystery Box Giveaway Winner" Phishing below is back again, this time something about "United Health Group"...
+# Directs to formally-up.com
+zwbufziw6o4q92.s3.amazonaws.com
+
 # "Shein Mystery Box Giveaway Winner" Phishing
 formally-up.com
 lvrv0gkspz.blob.core.windows.net


### PR DESCRIPTION
Same folks as the last phishing domain I reported (The "Shein Mystery Box" scam email I received) are back at it again... this time something about a "United Health Group". Links in email go to `zwbufziw6o4q92.s3.amazonaws.com`, which navigates to `formally-up.com`.

![image](https://github.com/user-attachments/assets/51838185-b202-4acb-a672-3328097b5a9b)

![image](https://github.com/user-attachments/assets/db4dadc5-db65-4369-ae91-e10d04da8db8)
