### PR TITLE
Update deny_gambling.txt

### DIFF
--- a/submit_pullrequest_here/deny_gambling.txt
+++ b/submit_pullrequest_here/deny_gambling.txt
@@ -40745,6 +40745,7 @@ belakangtaruh4d.lol
 belamisu1290.site
 belanh79.vip
 belasg04.site
+belbet.by
 belegendwinlink21.com
 belegendwinlink22.com
 belikamu.com


### PR DESCRIPTION
Belbet.by is an online gambling site, and adding it to the DNS gambling blacklist would help protect people from the dangers of gambling, like addiction and financial loss. Plus, it would make sure we're sticking to the rules and keeping everyone safer online.