### PR TITLE
Allow wapo.pub

### DIFF
--- a/submit_pullrequest_here/allow_spam_TLDs.txt
+++ b/submit_pullrequest_here/allow_spam_TLDs.txt
@@ -212,6 +212,7 @@ tux.pizza
 gamedev.place
 casey.prof
 infosec.pub
+wapo.pub
 dice.quest
 epochal.quest
 mhn.quest


### PR DESCRIPTION
Legitimate domain operated by the Washington Post, appears to be used for media & audio playback