### PR TITLE
Unblock legitimate domains belonging to the Indianapolis Star

### DIFF
--- a/submit_pullrequest_here/allow_light-ultimate.txt
+++ b/submit_pullrequest_here/allow_light-ultimate.txt
@@ -24,9 +24,10 @@ ininotesb.indystar.com
 m.indystar.com
 newsfromyou.indystar.com
 photos.indystar.com
-profile.indystar.com
 profile-stage.indystar.com
+profile.indystar.com
 rssfeeds.indystar.com
+sp.indystar.com
 stage.indystar.com
 static.indystar.com
 subscribe.indystar.com

--- a/submit_pullrequest_here/allow_light-ultimate.txt
+++ b/submit_pullrequest_here/allow_light-ultimate.txt
@@ -1,6 +1,42 @@
 # Unblocking for all lists (relaxed, balanced, aggressive and strict)
 # Domains to be removed from the light, normal, pro, pro++ and ultimate list. Also from the fake, popupads and tif.
 
+indystar.com
+account.indystar.com
+amp.indystar.com
+archive.indystar.com
+atoms.indystar.com
+blogs.indystar.com
+checkout.indystar.com
+cm.indystar.com
+connect.indystar.com
+data.indystar.com
+databases.indystar.com
+elections16.indystar.com
+eu.indystar.com
+foodandwine.indystar.com
+gdn.indystar.com
+help.indystar.com
+hiring.indystar.com
+ininotes.indystar.com
+ininotesb.indystar.com
+m.indystar.com
+newsfromyou.indystar.com
+photos.indystar.com
+profile.indystar.com
+profile-stage.indystar.com
+rssfeeds.indystar.com
+stage.indystar.com
+static.indystar.com
+subscribe.indystar.com
+support.indystar.com
+topics.indystar.com
+user.indystar.com
+uw-media.indystar.com
+ux.indystar.com
+www.indystar.com
+www2.indystar.com
+
 # https://github.com/hagezi/dns-blocklists/issues/4537
 forcesafesearch.google.com
 

--- a/submit_pullrequest_here/allow_light-ultimate.txt
+++ b/submit_pullrequest_here/allow_light-ultimate.txt
@@ -1,6 +1,7 @@
 # Unblocking for all lists (relaxed, balanced, aggressive and strict)
 # Domains to be removed from the light, normal, pro, pro++ and ultimate list. Also from the fake, popupads and tif.
 
+# https://github.com/hagezi/dns-blocklists/pull/4582
 indystar.com
 account.indystar.com
 amp.indystar.com


### PR DESCRIPTION
These are legitimate domains used by [The Indianapolis Star](https://wikipedia.org/wiki/The_Indianapolis_Star), a news outlet.

`ads.indystar.com`, `gcirm.indystar.com`, `sli.indystar.com`, `sp.indystar.com`, `srepdata.indystar.com`, & `sxjfhh.indystar.com` **should remain blocked**, as they are actually used for advertising & tracking, **but the rest should be removed.**

I wonder how these all got blocked in the first place? Was especially surprised to see each individual subdomain like this... 🤔