### PR TITLE
Update repository_README.txt

### DIFF
--- a/submit_pullrequest_here/repository_README.txt
+++ b/submit_pullrequest_here/repository_README.txt
@@ -733,11 +733,11 @@ In [DNSwarden](https://dnswarden.com/customfilter.html) you can use my Light, No
 
 #### :department_store: **SCHONET DNS (Germany) - free** <a name="schonetdns"></a>
 
-[SCHONET DNS (Germany)](https://schonet-dns.de/) uses my Multi Pro++ in combination with the TIF blocklist and [@xRuffKez](https://github.com/xRuffKez/NRD) NRD 30.
+[DNSBunker (Germany)](https://dnsbunker.org/) uses my Multi Pro++ in combination with the TIF blocklist and [@xRuffKez](https://github.com/xRuffKez/NRD) NRD 30.
 
 | Blocklists | DNS-over-HTTPS | DNS-over-TLS/QUIC | Legacy DNS |
 |:-----------|:---------------|:------------------|:-----------|
-| Pro plus + TIF + NRD | `https://schonet-dns.de/dns-query` | `schonet-dns.de` | 89.163.255.195<br>2001:4ba0:babe:3734:: |
+| Pro plus + TIF + NRD | `https://dnsbunker.org/dns-query` | `dnsbunker.org` | 89.163.255.195<br>2001:4ba0:babe:3734:: |
 
 #### :department_store: **OpenBLD.net - free** <a name="openbld"></a>
 

--- a/submit_pullrequest_here/repository_README.txt
+++ b/submit_pullrequest_here/repository_README.txt
@@ -733,11 +733,11 @@ In [DNSwarden](https://dnswarden.com/customfilter.html) you can use my Light, No
 
 #### :department_store: **SCHONET DNS (Germany) - free** <a name="schonetdns"></a>
 
-[DNSBunker (Germany)](https://dnsbunker.org/) uses my Multi Pro++ in combination with the TIF blocklist and [@xRuffKez](https://github.com/xRuffKez/NRD) NRD 30.
+[DNSBunker (Germany)](https://dnsbunker.org/) uses my Multi Pro++ in combination with the TIF blocklist and [@xRuffKez](https://github.com/xRuffKez/NRD) NRD/DGA.
 
 | Blocklists | DNS-over-HTTPS | DNS-over-TLS/QUIC | Legacy DNS |
 |:-----------|:---------------|:------------------|:-----------|
-| Pro plus + TIF + NRD | `https://dnsbunker.org/dns-query` | `dnsbunker.org` | 89.163.255.195<br>2001:4ba0:babe:3734:: |
+| Pro plus + TIF + NRD30 Phishing/DGA | `https://dnsbunker.org/dns-query` | `dnsbunker.org` | 89.163.255.195<br>2001:4ba0:babe:3734:: |
 
 #### :department_store: **OpenBLD.net - free** <a name="openbld"></a>
 


### PR DESCRIPTION
New Domain: dnsbunker.org
Certificate is bound to schonet-dns.de and dnsbunker.org Does not interfere with clients which uses the old domain. Avoiding Telemediengesetz (.de domain) publishing of my private address on Impressum and New domain Sounds better and more professional...