### PR TITLE
Unblock `makea.zip` on `Most Abused TLDs`

### DIFF
--- a/submit_pullrequest_here/allow_spam_TLDs.txt
+++ b/submit_pullrequest_here/allow_spam_TLDs.txt
@@ -452,4 +452,5 @@ sinking.yachts
 community.zip
 financialstatement.zip
 lemmy.zip
+makea.zip
 uploaded-files.zip


### PR DESCRIPTION
Legitimate domain, just used for creating `.zip` files...