### PR TITLE
Unblock `itsatracker.com` & `trackertest.org`

### DIFF
--- a/submit_pullrequest_here/allow_light-ultimate.txt
+++ b/submit_pullrequest_here/allow_light-ultimate.txt
@@ -1,6 +1,11 @@
 # Unblocking for all lists (relaxed, balanced, aggressive and strict)
 # Domains to be removed from the light, normal, pro, pro++ and ultimate list. Also from the fake, popupads and tif.
 
+# Mozilla domains used for Firefox's tracking protection, not used for actual tracking...
+# https://github.com/mozilla/trackertest
+itisatracker.com
+trackertest.org
+
 # Blocks the location search in the weather app
 *-weather.vivoglobal.com
 


### PR DESCRIPTION
These are used to test Firefox's tracking protection, not actual trackers... 

*(See https://github.com/mozilla/trackertest)*