### PR TITLE
Update repository_README.txt

### DIFF
--- a/submit_pullrequest_here/repository_README.txt
+++ b/submit_pullrequest_here/repository_README.txt
@@ -795,7 +795,7 @@ In [DNSwarden](https://dnswarden.com/customfilter.html) you can use my Light, No
 
 | Blocklists | DNS-over-HTTPS | DNS-over-TLS/QUIC | Legacy DNS |
 |:-----------|:---------------|:------------------|:-----------|
-| Pro plus + Native Tracker + TIF + NRD30 Phishing/DGA | `https://dnsbunker.org/dns-query` | `dnsbunker.org` | 87.106.108.91<br>87.106.32.13<br>2a01:239:295:e800::1<br>2a01:239:290:e700::1 |
+| Pro plus + Native Tracker + TIF | `https://dnsbunker.org/dns-query` | `dnsbunker.org` | 87.106.108.91<br>87.106.32.13<br>2a01:239:295:e800::1<br>2a01:239:290:e700::1 |
 
 #### :department_store: **OpenBLD.net - free** <a name="openbld"></a>
 


### PR DESCRIPTION
Removed DGA/NRD description.
I got many emails lately of broken services (mostly warez and streaming sites) and have removed DGA and NRD Lists from the public resolvers. Will relay on TIF in future. Above lists seems to be not suitable for public resolvers. Check website which lists are in use if you want to know more.