### PR TITLE
Add arduino.cc to allow_spam_TLDs.txt

### DIFF
--- a/submit_pullrequest_here/allow_spam_TLDs.txt
+++ b/submit_pullrequest_here/allow_spam_TLDs.txt
@@ -518,3 +518,4 @@ financialstatement.zip
 lemmy.zip
 makea.zip
 uploaded-files.zip
+arduino.cc


### PR DESCRIPTION
To unblock arduino.cc caugh by *.cc (replicating other PR, not sure if this is the way to do it).