### PR TITLE
Add lilygo.cc to allow_spam_TLDs.txt

### DIFF
--- a/submit_pullrequest_here/allow_spam_TLDs.txt
+++ b/submit_pullrequest_here/allow_spam_TLDs.txt
@@ -53,6 +53,7 @@ dict.cc
 fanbox.cc
 frontrow.cc
 is.cc
+lilygo.cc
 postimg.cc
 rapidcdn.cc
 shottr.cc


### PR DESCRIPTION
DIY electronics providers seem to like .cc