### PR TITLE
remove: graph.facebook.com

### DIFF
--- a/share/facebook.txt
+++ b/share/facebook.txt
@@ -3,7 +3,6 @@
 b-graph-fallback.facebook.com
 b-graph.facebook.com
 graph-fallback.facebook.com
-graph.facebook.com
 graph.fbpigeon.com
 graph.m-freeway.com
 z-m-graph.facebook.com


### PR DESCRIPTION
Removing graph.facebook.com due to frequent feed refresh issues reported primarily by mobile application users.