### PR TITLE
Update: allow shopdisney.asia

### DIFF
--- a/adblock/spam-tlds-adblock-allow.txt
+++ b/adblock/spam-tlds-adblock-allow.txt
@@ -16,6 +16,7 @@
 @@||homelands.asia^
 @@||pansci.asia^
 @@||rainviewer.asia^
+@@||shopdisney.asia^
 @@||fap.bar^
 @@||strem.bar^
 @@||epg.best^

--- a/adblock/spam-tlds-ublock.txt
+++ b/adblock/spam-tlds-ublock.txt
@@ -21,7 +21,7 @@
 ||agency^$doc,domain=~apptoro.agency|~baam.agency|~battlefield.agency|~byteful.agency|~robotzebra.agency|~uphotel.agency|~usenet.agency|~ws.agency
 ||apartments^$doc
 ||army^$doc,domain=~phishing.army
-||asia^$doc,domain=~amzn.asia|~autoads.asia|~bandainamcoent.asia|~dbankcloud.asia|~elgaucho.asia|~homelands.asia|~pansci.asia|~rainviewer.asia
+||asia^$doc,domain=~amzn.asia|~autoads.asia|~bandainamcoent.asia|~dbankcloud.asia|~elgaucho.asia|~homelands.asia|~pansci.asia|~rainviewer.asia|~shopdisney.asia
 ||auction^$doc
 ||autos^$doc
 ||baby^$doc

--- a/adblock/spam-tlds.txt
+++ b/adblock/spam-tlds.txt
@@ -20,7 +20,7 @@
 ||*.agency^$denyallow=apptoro.agency|baam.agency|battlefield.agency|byteful.agency|robotzebra.agency|uphotel.agency|usenet.agency|ws.agency
 ||*.apartments^
 ||*.army^$denyallow=phishing.army
-||*.asia^$denyallow=amzn.asia|autoads.asia|bandainamcoent.asia|dbankcloud.asia|elgaucho.asia|homelands.asia|pansci.asia|rainviewer.asia
+||*.asia^$denyallow=amzn.asia|autoads.asia|bandainamcoent.asia|dbankcloud.asia|elgaucho.asia|homelands.asia|pansci.asia|rainviewer.asia|shopdisney.asia
 ||*.auction^
 ||*.autos^
 ||*.baby^


### PR DESCRIPTION
https://www.disneystore.com.au uses shopdisney.asia as a CDN domain. Suggesting your consideration for exclusion from the 'most abused TLDs' list.

Thanks!