### PR TITLE
Allow: vlo.name

### DIFF
--- a/submit_pullrequest_here/allow_spam_TLDs.txt
+++ b/submit_pullrequest_here/allow_spam_TLDs.txt
@@ -322,6 +322,7 @@ pstream.mov
 chris.boyle.name
 davidwalsh.name
 stefvanbuuren.name
+vlo.name
 bolt.new
 doc.new
 drawing.new


### PR DESCRIPTION
A site distributing utilities such as SSD Flash ID checkers.
Accessible via port 3000.
For example: `http://vlo[.]name:3000/ssdtool/`