### PR TITLE
Remove Datadog NTP servers from deny list

### DIFF
--- a/submit_pullrequest_here/deny_proplus-ultimate.txt
+++ b/submit_pullrequest_here/deny_proplus-ultimate.txt
@@ -36,13 +36,6 @@ recengine.margera.co
 # https://github.com/hagezi/dns-blocklists/issues/4743
 click.revolut.com
 
-# https://github.com/hagezi/dns-blocklists/issues/4400
-0.datadog.pool.ntp.org
-1.datadog.pool.ntp.org
-2.datadog.pool.ntp.org
-3.datadog.pool.ntp.org
-datadog.pool.ntp.org
-
 # https://github.com/hagezi/dns-blocklists/issues/4380
 ntd-asus-2014b-en.fbs20.trendmicro.com
 ntd-asus-2014b-en-cfg.fbs20.trendmicro.com


### PR DESCRIPTION
Remove Datadog NTP servers from the deny list.  These servers are legitimate NTP servers that participate in the NTP Pool Project/ NTP requests that are allocated  to these servers in the pool are failing.

Fixes #7276.