### PR TITLE
Allow: tmaeno.tokyo

### DIFF
--- a/submit_pullrequest_here/allow_spam_TLDs.txt
+++ b/submit_pullrequest_here/allow_spam_TLDs.txt
@@ -560,6 +560,7 @@ futurology.today
 lemmy.today
 oldweb.today
 type.today
+tmaeno.tokyo
 ambr.top
 caitlin.top
 corriente.top


### PR DESCRIPTION
Toshinori Maeno's personal website.  
`moin.tmaeno[.]tokyo` and more.