### PR TITLE
Allow: miteru.site

### DIFF
--- a/submit_pullrequest_here/allow_spam_TLDs.txt
+++ b/submit_pullrequest_here/allow_spam_TLDs.txt
@@ -470,6 +470,7 @@ gov-img.site
 heyflow.site
 i5i.site
 kaylees.site
+miteru.site
 notion.site
 onrocket.site
 platformsh.site


### PR DESCRIPTION
MiTERU Inc. official website.  
A company that deals with the management of online criticism and related problems.