### PR TITLE
allow 'dmn.moe' 

### DIFF
--- a/submit_pullrequest_here/allow_spam_TLDs.txt
+++ b/submit_pullrequest_here/allow_spam_TLDs.txt
@@ -344,6 +344,7 @@ catbox.moe
 cdn.moe
 cubari.moe
 ddlc.moe
+dmn.moe
 honse.moe
 mathi.moe
 nyarchlinux.moe


### PR DESCRIPTION
[vrchat's yt world](https://vrchat.com/home/launch?worldId=wrld_900dd077-1337-c0fe-babe-71de05ea12c4) doesn't work when this is blocked 