### PR TITLE
fix: Allow `guns.lol` on Most Abused TLDs

### DIFF
--- a/submit_pullrequest_here/allow_spam_TLDs.txt
+++ b/submit_pullrequest_here/allow_spam_TLDs.txt
@@ -316,6 +316,7 @@ animevietsub.lol
 browser.lol
 dankmemer.lol
 fmhy.lol
+guns.lol
 hubcloud.lol
 io.lol
 kizuki.lol


### PR DESCRIPTION
This is a legitimate domain; `guns.lol` is a "link-in-bio platform" that allows users to easily share/display relevant links from their bio.