### PR TITLE
Added forceofwind.online to allow_spam_TLDs.txt

### DIFF
--- a/submit_pullrequest_here/allow_spam_TLDs.txt
+++ b/submit_pullrequest_here/allow_spam_TLDs.txt
@@ -420,6 +420,7 @@ dnsspeedtest.online
 eufh.online
 fireshinegames.online
 flexilead.online
+forceofwind.online
 geoigarape.online
 grapheneos.online
 incdn.online


### PR DESCRIPTION
Added `forceofwind.online` to allow_spam_TLDs.txt.  
forceofwind.online is a popular deck building website for the Force of Will trading card game.