### PR TITLE
Allow 'minecraft.hot' TLD in spam list

### DIFF
--- a/submit_pullrequest_here/allow_spam_TLDs.txt
+++ b/submit_pullrequest_here/allow_spam_TLDs.txt
@@ -277,6 +277,7 @@ gorgias.help
 kustomer.help
 pixiv.help
 stremio.homes
+minecraft.hot
 lanparty.house
 nature.house
 mond.how


### PR DESCRIPTION
Added `minecraft.hot` to the list of `allowed_spam_TLDs.txt`.  
minecraft.hot is a legitimate domain where a minecraft server is hosted for players to join.