### PR TITLE
Update doh-vpn-proxy-bypass.txt removed api1.flyier.xyz

### DIFF
--- a/dnsmasq/doh-vpn-proxy-bypass.txt
+++ b/dnsmasq/doh-vpn-proxy-bypass.txt
@@ -5594,7 +5594,6 @@ local=/dns.flwagners.com/
 local=/dns.flyer.vn/
 local=/flyfishnwa.com/
 local=/selenite.flyfresh.net/
-local=/api1.flyier.xyz/
 local=/flyingsnow.store/
 local=/dns.flymc.cc/
 local=/flymetothemoon.work/


### PR DESCRIPTION
Site is no longer valid. And is now used for grading. 