### PR TITLE
allow: add ze.delivery to allowed_spam_TLDs

### DIFF
--- a/submit_pullrequest_here/allow_spam_TLDs.txt
+++ b/submit_pullrequest_here/allow_spam_TLDs.txt
@@ -196,6 +196,7 @@ opf.degree
 three60.degree
 push.delivery
 return-my.delivery
+ze.delivery
 xhamster.desi
 2fa.directory
 cursor.directory


### PR DESCRIPTION
This PR adds `ze.delivery` to the `allowed_spam_TLDs.txt`

`ze.delivery` is the official domain of Zé Delivery, a legitimate beverage delivery platform operating across South America and Central America. The domain is actively used for lawful commercial services.