### PR TITLE
allow: adds readme.club and meucarrinho.delivery to allowed_spam_TLDs

### DIFF
--- a/submit_pullrequest_here/allow_spam_TLDs.txt
+++ b/submit_pullrequest_here/allow_spam_TLDs.txt
@@ -164,6 +164,7 @@ j-novel.club
 mbcherohub.club
 nocss.club
 no-js.club
+readme.club
 rwinfo.club
 skin.club
 thelemmy.club
@@ -194,6 +195,7 @@ gaudi.dating
 gg.deals
 opf.degree
 three60.degree
+meucarrinho.delivery
 push.delivery
 return-my.delivery
 ze.delivery


### PR DESCRIPTION
This PR adds the following domains to `allowed_spam_TLDs.txt`:

- `readme.club` – legitimate community-driven resource sharing platform for Xteink users, providing guides, tools, and shared content.

- `meucarrinho.delivery` – legitimate Brazilian local ordering and delivery platform used by restaurants and small businesses.
